### PR TITLE
for mem cards, nm uses one ticket (raffle/event)

### DIFF
--- a/src/pages/membership.tsx
+++ b/src/pages/membership.tsx
@@ -94,8 +94,7 @@ function MembershipPage(props: Props) {
                         </li>
                         <li>
                             <Text>
-                                Free Raffle Tickets at Tour of Taiwan and Night 
-                                Market
+                                Free Raffle Tickets at Tour of Taiwan
                             </Text>
                         </li>
                     </ul>


### PR DESCRIPTION
Night Market is only using a one ticket system (one ticket to represent raffle and games/activities/food), so updated the benefits to reflect that. Still will get tickets for raffle and event but just labelled as one ticket